### PR TITLE
Updated install instructions for 0.3 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add `"petebrowne/slim-layout-view"` to your `composer.json` file:
 {
   "require": {
     "slim/slim": "2.*",
-    "petebrowne/slim-layout-view": "0.2.*"
+    "petebrowne/slim-layout-view": "0.3.*"
   }
 }
 ```


### PR DESCRIPTION
I noticed too late that the install instructions were at fault, not the Slim\View::fetch overloading that I was planning on fixing :) 

Thanks for this, btw!
